### PR TITLE
Make node services respect SERVICE_MAX_TIMEOUT

### DIFF
--- a/lib/spawn.js
+++ b/lib/spawn.js
@@ -244,7 +244,7 @@ module['exports'] = function spawnService (service, input, output) {
         var __env = {
           params: input.resource.instance || input.resource.params, // instance is used in case of validation
           isStreaming: isStreaming,
-          customTimeout: service.customTimeout, // replace with _service scope?
+          customTimeout: service.customTimeout || config.SERVICE_MAX_TIMEOUT, // replace with _service scope?
           env: input.env,
           resource: _service,
           input: {


### PR DESCRIPTION
While using `stack` from cli with `-t` flag `SERVICE_MAX_TIMEOUT` don't respected for services in `node` as it use `run-service` which has own default (10 seconds) for timeout in case `customTimeout` not specified.
